### PR TITLE
Improved installation by Docker, composes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,24 @@
-FROM python:3.11.1
+FROM python:3.11.1-alpine as base
+FROM base as builder
+
+RUN mkdir /install
+WORKDIR /usr/src/app
+
+RUN python -m venv /usr/src/app/venv
+ENV PATH="/usr/src/app/venv/bin:$PATH"
+
+COPY ./src/requirements.txt requirements.txt
+
+RUN pip install -r requirements.txt
+
+FROM base
 
 WORKDIR /usr/src/app
+
+COPY --from=builder /usr/src/app/venv ./venv
 COPY ./src/ .
-RUN pip install --no-cache-dir -r requirements.txt
-RUN chmod +x entrypoint.sh
+
+ENV PATH="/usr/src/app/venv/bin:$PATH"
+RUN chmod +x ./entrypoint.sh
 
 ENTRYPOINT [ "./entrypoint.sh" ]

--- a/compose.yml
+++ b/compose.yml
@@ -6,6 +6,8 @@ services:
       - 80:80
     depends_on:
       - database
+    networks:
+      - syncroapi
 
   database:
     image: mariadb
@@ -13,3 +15,8 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: root
       MYSQL_DATABASE: api
+    networks:
+      - syncroapi
+
+networks:
+  syncroapi:

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -1,8 +1,10 @@
-#!/bin/bash
+#!/bin/sh
 
-cd ./database
+ROOT_DIR=$(pwd)
+
+cd "$ROOT_DIR/database"
 alembic revision --autogenerate
 alembic upgrade heads
 
-cd ../
+cd "$ROOT_DIR"
 python main.py


### PR DESCRIPTION
- Optimization of the backend image
Creation by a multi-layer image

- Security improvement
Creation of an internal docker network compose.

Use of the `python:3.11.1-alpine` image. Bash is not available anymore we will use `sh`.